### PR TITLE
Fix: Add `-N` for stop listening after request

### DIFF
--- a/shinatra.sh
+++ b/shinatra.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 RESPONSE="HTTP/1.1 200 OK\r\nConnection: keep-alive\r\n\r\n${2:-"OK"}\r\n"
-while { echo -en "$RESPONSE"; } | nc -l "${1:-8080}"; do
+while { echo -en "$RESPONSE"; } | nc -l -N "${1:-8080}"; do
   echo "================================================"
 done


### PR DESCRIPTION
I add the -N option who allow to have end of request when we receive it.

From manual: '-N      shutdown(2) the network socket after EOF on the input.  Some servers require this to finish their work.'

Enjoy and have a nice day !