### PR TITLE
Ncat instead of netcat/nc

### DIFF
--- a/shinatra.sh
+++ b/shinatra.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 RESPONSE="HTTP/1.1 200 OK\r\nConnection: keep-alive\r\n\r\n${2:-"OK"}\r\n"
-while { echo -en "$RESPONSE"; } | nc -l "${1:-8080}"; do
+while { echo -en "$RESPONSE"; } | ncat -l "${1:-8080}"; do
   echo "================================================"
 done


### PR DESCRIPTION
I suggest to replace nc command by the more modern ncat command (source: https://www.cybrary.it/blog/0p3n/netcat-vs-ncat-big-confusion/)

In more, this allow to close the connection in the browser.

You need to install the ncat command.

